### PR TITLE
Add white shadow to cards descriptions

### DIFF
--- a/Abby.Web/Pages/Customer/Home/Index.cshtml
+++ b/Abby.Web/Pages/Customer/Home/Index.cshtml
@@ -47,7 +47,8 @@
                         <div class="col-6 border-0">
                             <span class="badge p-2 border w-100 bg-info ">@menuItem.FoodType.Name</span>
                         </div>
-                        <div class="col-12 pt-2" style="font-size:13px; text-align:justify;height:210px;overflow:auto">
+                        <div class="col-12 pt-2" style="font-size:13px;text-align:justify;height:207px;overflow:hidden;position:relative;">
+                            <div style="position:absolute;width:100%;height:30%;bottom:0;background:linear-gradient(to bottom,transparent 10%,white 100%);"></div>
                             <p> @Html.Raw(menuItem.Description.Replace("\n", "<br />"))</p>
                         </div>
                         <div class="col-12 p-1">


### PR DESCRIPTION
Added a subtle white shadow/fade to card components to enhance visual clarity and create a smoother, more polished look. 

### Visual Comparison

| **Before** | **After** |
|------------|-----------|
| ![Screenshot 2024-09-22 205936](https://github.com/user-attachments/assets/62419bf9-fe29-433f-b3c6-8068fe2c449a) | ![Screenshot 2024-09-22 205835](https://github.com/user-attachments/assets/0f78ecf6-8816-44b2-84d7-0ea35ae97186) |


